### PR TITLE
Please fix examples

### DIFF
--- a/examples/Generate.cpp
+++ b/examples/Generate.cpp
@@ -4,16 +4,16 @@
 #include <iostream>
 
 int main() {
-    	std::size_t counter = 0;
+	std::size_t counter = 0;
 	static constexpr std::size_t amount = 4;
-    	auto gen = lz::generate(
-        	[](std::size_t& c) {
-            		auto tmp{ c++ };
-            		return tmp;
+	auto gen = lz::generate(
+		[](std::size_t& c) {
+			auto tmp{ c++ };
+			return tmp;
 		},
-        	amount, counter);
+		amount, counter);
 
-    	std::cout << gen << '\n';
+	std::cout << gen << '\n';
 	// Output: 0 1 2 3
 	for (int i : gen) {
 		// Process i...

--- a/examples/Take.cpp
+++ b/examples/Take.cpp
@@ -22,7 +22,7 @@ int main() {
 		// process i...
 	}
 	
-    const auto slice = lz::view(seq.begin() + 1, seq.end() + 4);
+    const auto slice = lz::view(seq.begin() + 1, seq.begin() + 4);
     std::cout << slice << '\n';
     // Output: 2 3 4
 


### PR DESCRIPTION
There are several improvements in examples.

- fix indent in Generate.cpp
- use `seq.begin()` instead of `seq.end()` in Take.cpp
