### PR TITLE
include missing sstream to stream

### DIFF
--- a/include/Lz/stream.hpp
+++ b/include/Lz/stream.hpp
@@ -31,6 +31,8 @@
   #endif
 #elif defined(LZ_HAS_FORMAT)
   #include <format>
+#else
+  #include <sstream>
 #endif // !defined(LZ_STANDALONE)
 
 // clang-format on


### PR DESCRIPTION
The type `std::ostringstream ` is included in the `sstream` class: https://en.cppreference.com/w/cpp/io/basic_ostringstream.html

`stream.hpp` uses this type without including the standar header:
https://github.com/Kaaserne/cpp-lazy/blob/ac1280f02732e60985d9f668aa72e7d8a59e025c/include/Lz/stream.hpp#L289

This is generating me the next error:
```
...
FAILED: [code=1] CMakeFiles/test_package.dir/test_package.cpp.o 
/usr/bin/c++ -DCPP_LAZY_9_0_0_NEWER -isystem /Users/ernesto/.conan2/p/b/cpp-l1b5e6b4172af6/p/include -stdlib=libc++ -O3 -DNDEBUG -std=gnu++20 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk -mmacosx-version-min=13.0 -MD -MT CMakeFiles/test_package.dir/test_package.cpp.o -MF CMakeFiles/test_package.dir/test_package.cpp.o.d -o CMakeFiles/test_package.dir/test_package.cpp.o -c /Users/ernesto/Documents/GitHub/conan-center-index/recipes/cpp-lazy/all/test_package/test_package.cpp
In file included from /Users/ernesto/Documents/GitHub/conan-center-index/recipes/cpp-lazy/all/test_package/test_package.cpp:6:
/Users/ernesto/.conan2/p/b/cpp-l1b5e6b4172af6/p/include/Lz/stream.hpp:289:28: error: implicit instantiation of undefined template 'std::basic_ostringstream<char>'
  289 |         std::ostringstream oss;
      |                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk/usr/include/c++/v1/__fwd/sstream.h:28:28: note: template is declared here
   28 | class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
      |                            ^
1 error generated.
ninja: build stopped: subcommand failed.
```